### PR TITLE
Feature: Import OTPs from ZIP archive

### DIFF
--- a/Raivo.xcodeproj/project.pbxproj
+++ b/Raivo.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1F108CD329CFD578007D7D8F /* MainDataImportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F108CD229CFD578007D7D8F /* MainDataImportView.swift */; };
+		1F108CD529CFD5B8007D7D8F /* DataImportFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F108CD429CFD5B8007D7D8F /* DataImportFeature.swift */; };
+		1F108CD729CFD5FA007D7D8F /* MainDataImportViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F108CD629CFD5FA007D7D8F /* MainDataImportViewController.swift */; };
+		1F108CD929CFD686007D7D8F /* MainDataImportViewObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F108CD829CFD686007D7D8F /* MainDataImportViewObservable.swift */; };
 		700794B0279D6BC8007510A5 /* TokenExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 700794AF279D6BC8007510A5 /* TokenExtension.swift */; };
 		700908C521FCCE5F00603AA2 /* ApplicationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 700908C421FCCE5F00603AA2 /* ApplicationDelegate.swift */; };
 		700908C721FCCE5F00603AA2 /* MainEntryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 700908C621FCCE5F00603AA2 /* MainEntryViewController.swift */; };
@@ -224,6 +228,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1F108CD229CFD578007D7D8F /* MainDataImportView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainDataImportView.swift; sourceTree = "<group>"; };
+		1F108CD429CFD5B8007D7D8F /* DataImportFeature.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataImportFeature.swift; sourceTree = "<group>"; };
+		1F108CD629CFD5FA007D7D8F /* MainDataImportViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainDataImportViewController.swift; sourceTree = "<group>"; };
+		1F108CD829CFD686007D7D8F /* MainDataImportViewObservable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainDataImportViewObservable.swift; sourceTree = "<group>"; };
 		700794AF279D6BC8007510A5 /* TokenExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenExtension.swift; sourceTree = "<group>"; };
 		700908C121FCCE5F00603AA2 /* Raivo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Raivo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		700908C421FCCE5F00603AA2 /* ApplicationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationDelegate.swift; sourceTree = "<group>"; };
@@ -548,6 +556,7 @@
 		700908DC21FCE2A900603AA2 /* Main */ = {
 			isa = PBXGroup;
 			children = (
+				1F108CD629CFD5FA007D7D8F /* MainDataImportViewController.swift */,
 				700908C621FCCE5F00603AA2 /* MainEntryViewController.swift */,
 				70A7B10D223061D60084F15B /* MainPasswordsViewController.swift */,
 				70A7B10F223061E50084F15B /* MainScanPasswordViewController.swift */,
@@ -714,6 +723,7 @@
 		706122E3266EA99400121035 /* Main */ = {
 			isa = PBXGroup;
 			children = (
+				1F108CD829CFD686007D7D8F /* MainDataImportViewObservable.swift */,
 				706122E4266EA9AA00121035 /* MainDataExportViewObservable.swift */,
 				70ED04E026763A6D005C4D14 /* MainChangeAppIconViewObservable.swift */,
 				7092B9A426C932D500B10065 /* MainReceiversViewObservable.swift */,
@@ -806,6 +816,7 @@
 				70A3F50625CEF089004F053B /* Misc */,
 				70A3F50125CECA8C004F053B /* Buttons */,
 				70A3F4F925CDD282004F053B /* MainDataExportView.swift */,
+				1F108CD229CFD578007D7D8F /* MainDataImportView.swift */,
 				70ED04E226763A8E005C4D14 /* MainChangeAppIconView.swift */,
 				7092B9A226C9309400B10065 /* MainReceiversView.swift */,
 				700B993728BBE21D002F5731 /* MainDonateView.swift */,
@@ -982,6 +993,7 @@
 		70DC72E722A3F2B2006FE7B7 /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				1F108CD429CFD5B8007D7D8F /* DataImportFeature.swift */,
 				70DC72E822A3F2FC006FE7B7 /* ComposeMailFeature.swift */,
 				70DC72EA22A3F306006FE7B7 /* DataExportFeature.swift */,
 				705E431F23E5D01B00D26619 /* AddTappedUriFeature.swift */,
@@ -1302,9 +1314,11 @@
 				70675F262677D874009A7AE9 /* AppIconObject.swift in Sources */,
 				70B585EF2309D3BE00AD1754 /* SetupPasscodeViewController.swift in Sources */,
 				700908C721FCCE5F00603AA2 /* MainEntryViewController.swift in Sources */,
+				1F108CD729CFD5FA007D7D8F /* MainDataImportViewController.swift in Sources */,
 				70B585EA2309BED700AD1754 /* SetupEncryptionInitialViewController.swift in Sources */,
 				702BAEA82258FD1B008E5C5F /* PasswordForm.swift in Sources */,
 				70B585E62309A67E00AD1754 /* SetupMiscViewController.swift in Sources */,
+				1F108CD929CFD686007D7D8F /* MainDataImportViewObservable.swift in Sources */,
 				70AE33252273B73D007A12A2 /* MigrationProtocol.swift in Sources */,
 				70A3F4FA25CDD282004F053B /* MainDataExportView.swift in Sources */,
 				70BC3EE222567603005C98EF /* BaseSyncer.swift in Sources */,
@@ -1342,6 +1356,7 @@
 				70B55862225E761800F83A34 /* PasswordCell.swift in Sources */,
 				70A1BC5322F74E6100152864 /* ErrorRootViewController.swift in Sources */,
 				709B636122C548E800697884 /* QuickResponseCodeRow.swift in Sources */,
+				1F108CD529CFD5B8007D7D8F /* DataImportFeature.swift in Sources */,
 				7077A33B227CCB1200338CA3 /* PasswordDigitsFormOption.swift in Sources */,
 				7065070A23106E0A004D6E84 /* ErrorDowngradeNotPermittedViewController.swift in Sources */,
 				7092B9B026C96BF600B10065 /* ValidationError.swift in Sources */,
@@ -1372,6 +1387,7 @@
 				70ED04E326763A8E005C4D14 /* MainChangeAppIconView.swift in Sources */,
 				70BD738425B9BA4D002F9347 /* MainDataExportViewController.swift in Sources */,
 				700908F021FCEC3100603AA2 /* SetupEntryViewController.swift in Sources */,
+				1F108CD329CFD578007D7D8F /* MainDataImportView.swift in Sources */,
 				70684DED225A1BD40038BDB4 /* ApplicationPrincipal.swift in Sources */,
 				702A140A2263672200B278BB /* MainChangePasscodeViewController.swift in Sources */,
 				7076C22622E7909000AFBDD9 /* MainQuickResponseCodeViewController.swift in Sources */,

--- a/Raivo/Controllers/Main/MainDataImportViewController.swift
+++ b/Raivo/Controllers/Main/MainDataImportViewController.swift
@@ -1,0 +1,22 @@
+//
+// Raivo OTP
+//
+// Copyright (c) 2022 Tijme Gommers. All rights reserved. 
+//
+// View the license that applies to the Raivo OTP source 
+// code and published services to learn how you can use
+// Raivo OTP.
+//
+// https://raivo-otp.com/license/.
+
+import Foundation
+import UIKit
+import SwiftUI
+
+class MainDataImportViewController: UIHostingController<MainDataImportView> {
+    
+    required init?(coder aDecoder: NSCoder){
+        super.init(coder: aDecoder, rootView: MainDataImportView(mainDataImport: MainDataImportViewObservable()))
+    }
+
+}

--- a/Raivo/Features/DataImportFeature.swift
+++ b/Raivo/Features/DataImportFeature.swift
@@ -114,7 +114,7 @@ class DataImportFeature {
         return nil
     }
     
-    public func importArchive(archiveFileURL: URL, withPassword password: String) -> (title: String, message: String) {
+    public func importArchive(archiveFileURL: URL, withPassword password: String, shouldDeleteOldPasswords: Bool = false) -> (title: String, message: String) {
         
         func myError(_ message: String) -> (title: String, message: String) {
             return ("Import Failed", message)
@@ -131,7 +131,9 @@ class DataImportFeature {
         }
         
         // Clean up old passwords
-        deleteAllPasswords()
+        if shouldDeleteOldPasswords {
+            deleteAllPasswords()
+        }
         
         // Import new passwords
         if let result = importNewPasswords(data) {

--- a/Raivo/Features/DataImportFeature.swift
+++ b/Raivo/Features/DataImportFeature.swift
@@ -1,0 +1,111 @@
+//
+// Raivo OTP
+//
+// Copyright (c) 2022 Tijme Gommers. All rights reserved. 
+//
+// View the license that applies to the Raivo OTP source 
+// code and published services to learn how you can use
+// Raivo OTP.
+//
+// https://raivo-otp.com/license/.
+
+import ZipArchive
+import RealmSwift
+
+class DataImportFeature {
+    
+    private struct PasswordJson: Decodable {
+        let pinned: String
+        let iconValue: String
+        let secret: String
+        let issuer: String
+        let counter: String
+        let account: String
+        let iconType: String
+        let algorithm: String
+        let kind: String
+        let digits: String
+        let timer: String
+    }
+    
+    private func deleteFile(_ file: URL) {
+        try? FileManager.default.removeItem(at: file)
+    }
+    
+    private func deleteAllPasswords() {
+        if let realm = RealmHelper.shared.getRealm() {
+            let passwords = realm.objects(Password.self)
+            for password in passwords {
+                try? realm.write {
+                    password.deleted = true
+                }
+            }
+        }
+    }
+    
+    private func importNewPasswords(_ data: Data) {
+        let decoder = JSONDecoder()
+        do {
+            let jsonData = try decoder.decode([PasswordJson].self, from: data)
+            
+            for item in jsonData {
+                
+                // Construct a password
+                let password = Password()
+                password.id = password.getNewPrimaryKey()
+                password.issuer = item.issuer
+                password.account = item.account
+                password.iconType = item.iconType
+                password.iconValue = item.iconValue
+                password.secret = item.secret
+                password.algorithm = item.algorithm
+                password.digits = Int(item.digits) ?? 0
+                password.kind = item.kind
+                password.timer = Int(item.timer) ?? 0
+                password.counter = Int(item.counter) ?? 0
+                password.syncing = true
+                password.synced = false
+                password.pinned = Bool(item.pinned) ?? false
+                
+                // Store the password
+                if let realm = RealmHelper.shared.getRealm() {
+                    try realm.write {
+                        realm.add(password)
+                    }
+                }
+            }
+        } catch {
+            print("error importing passwords")
+        }
+    }
+    
+    public func importArchive(archiveFileURL: URL, withPassword password: String) -> (title: String, message: String) {
+        do {
+            // Unzip the file
+            let directory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+            try SSZipArchive.unzipFile(
+                atPath: archiveFileURL.path,
+                toDestination: directory.path,
+                overwrite: true,
+                password: password
+            )
+            
+            // Read the JSON data from the unzipped file
+            let filename = directory.appendingPathComponent("raivo-otp-export.json")
+            let data = try Data(contentsOf: filename)
+            deleteFile(filename)
+            
+            // Clean up old passwords
+            deleteAllPasswords()
+            
+            // Import new passwords
+            importNewPasswords(data)
+            
+            // Return success message
+            return ("Import Successful", "New OTPs were successfully imported from the ZIP archive.")
+        } catch {
+            // Return error message
+            return ("Import Failed", "Failed to import OTPs from ZIP archive.")
+        }
+    }
+}

--- a/Raivo/Forms/MiscellaneousForm.swift
+++ b/Raivo/Forms/MiscellaneousForm.swift
@@ -287,7 +287,7 @@ class MiscellaneousForm {
         form +++ Section("Data", { section in
             section.tag = "data"
             section.hidden = Condition(booleanLiteral: !authenticated)
-            section.footer = HeaderFooterView(title: "Your data will be exported in an encrypted ZIP archive (using your encryption password).")
+            //section.footer = HeaderFooterView(title: "Your data will be exported in an encrypted ZIP archive (using your encryption password).")
         })
             
             <<< ButtonRow("export", { row in
@@ -297,6 +297,15 @@ class MiscellaneousForm {
                 cell.imageView?.image = UIImage(named: "form-zip")
             }).onCellSelection({ cell, row in
                 controller.performSegue(withIdentifier: "MainDataExportSegue", sender: self)
+            })
+            
+            <<< ButtonRow("import", { row in
+                row.title = "Import OTPs from ZIP archive"
+            }).cellUpdate({ cell, row in
+                cell.textLabel?.textAlignment = .left
+                cell.imageView?.image = UIImage(named: "form-zip")
+            }).onCellSelection({ cell, row in
+                controller.performSegue(withIdentifier: "MainDataImportSegue", sender: self)
             })
     }
     

--- a/Raivo/Observables/Main/MainDataImportViewObservable.swift
+++ b/Raivo/Observables/Main/MainDataImportViewObservable.swift
@@ -1,0 +1,22 @@
+//
+// Raivo OTP
+//
+// Copyright (c) 2022 Tijme Gommers. All rights reserved. 
+//
+// View the license that applies to the Raivo OTP source 
+// code and published services to learn how you can use
+// Raivo OTP.
+//
+// https://raivo-otp.com/license/.
+
+import Foundation
+import Combine
+
+final class MainDataImportViewObservable: ObservableObject {
+    
+    @Published var busy = false
+    
+    @Published var present = false
+    
+    @Published var archive: URL? = nil
+}

--- a/Raivo/Storyboards/Base.lproj/Main.storyboard
+++ b/Raivo/Storyboards/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="zK7-fc-90e">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="zK7-fc-90e">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -231,6 +231,7 @@
                     <connections>
                         <segue destination="F9t-JF-c77" kind="show" identifier="MainChangePasscodeSegue" id="xHJ-LE-rn2"/>
                         <segue destination="P2U-OT-7BE" kind="show" identifier="MainDataExportSegue" id="r8T-aZ-TpT"/>
+                        <segue destination="sEj-Kk-mZP" kind="show" identifier="MainDataImportSegue" id="r8T-aZ-Tpt"/>
                         <segue destination="r26-NN-T5X" kind="show" identifier="MainChangeAppIconSegue" id="iHC-A0-yPr"/>
                         <segue destination="Oub-Y9-5bZ" kind="show" identifier="MainReceiversSegue" id="rWU-EU-9ek"/>
                         <segue destination="DXg-HA-DGt" kind="show" identifier="MainDonateSegue" id="klT-oe-U82"/>
@@ -390,9 +391,19 @@
             </objects>
             <point key="canvasLocation" x="2062" y="35"/>
         </scene>
+        <!--ZIP archive import-->
+        <scene sceneID="JGB-Vm-qMY">
+            <objects>
+                <hostingController title="ZIP archive import" hidesBottomBarWhenPushed="YES" id="sEj-Kk-mZP" customClass="MainDataImportViewController" customModule="Raivo" customModuleProvider="target" sceneMemberID="viewController">
+                    <navigationItem key="navigationItem" title="Import ZIP archive" id="UaO-RP-VXt"/>
+                </hostingController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="0l7-ej-48l" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="5639" y="1950"/>
+        </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="POH-4S-sTl"/>
+        <segue reference="oAN-q3-j0q"/>
     </inferredMetricsTieBreakers>
     <color key="tintColor" name="color-tint-red"/>
     <resources>

--- a/Raivo/Views/SwiftUI/MainDataImportView.swift
+++ b/Raivo/Views/SwiftUI/MainDataImportView.swift
@@ -86,7 +86,9 @@ struct MainDataImportView: View {
                     Divider()
                     Text("The ZIP archive you select is assumed to be a backup previously exported from Raivo. You will be asked to provide the password necessary to decrypt it, which may or may not differ from your current master password.")
                     Divider()
-                    Text("Any OTPs currently stored in Raivo will be erased. If in doubt, export your current OTPs first.")
+                    // Maybe revisit this idea in the future once there is a way to recover deleted OTPs?
+                    //Text("Any OTPs currently stored in Raivo will be erased. If in doubt, export your current OTPs first.")
+                    Text("Any OTPs currently stored in Raivo will not be erased nor overwritten.")
                     Divider()
                     Text("Your master password will not be changed.")
                 }

--- a/Raivo/Views/SwiftUI/MainDataImportView.swift
+++ b/Raivo/Views/SwiftUI/MainDataImportView.swift
@@ -1,0 +1,115 @@
+//
+// Raivo OTP
+//
+// Copyright (c) 2022 Tijme Gommers. All rights reserved.
+//
+// View the license that applies to the Raivo OTP source
+// code and published services to learn how you can use
+// Raivo OTP.
+//
+// https://raivo-otp.com/license/.
+
+import UIKit
+import SwiftUI
+import MobileCoreServices
+import UniformTypeIdentifiers
+
+// The main data import process: a linear series of actions using UIKit
+struct MainDataImportProcess: UIViewControllerRepresentable {
+    
+    class Coordinator: NSObject, UIDocumentPickerDelegate {
+        var parent: MainDataImportProcess
+        let dataImport = DataImportFeature()
+        
+        init(_ parent: MainDataImportProcess) {
+            self.parent = parent
+        }
+        
+        // Present an alert on the root view
+        private func doAlert(_ alertController: UIAlertController) {
+            let viewController = UIApplication.shared.windows.first?.rootViewController
+            viewController?.present(alertController, animated: true, completion: nil)
+        }
+        
+        // The user selected a file: prompt them for a password
+        func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+            let alertController = UIAlertController(title: "Enter Password", message: "Please enter the password for decrypting the selected ZIP archive.", preferredStyle: .alert)
+            alertController.addTextField { (textField) in
+                textField.placeholder = "Password"
+                textField.isSecureTextEntry = true
+            }
+            let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
+            let okAction = UIAlertAction(title: "OK", style: .default) { [ self] (action) in
+                guard let selectedFileURL = urls.first, let password = alertController.textFields?[0].text else { return }
+                // The user entered a password: attempt to import the archive, and report the outcome
+                let results = dataImport.importArchive(archiveFileURL: selectedFileURL, withPassword: password)
+                let alertController = UIAlertController(title: results.title, message: results.message, preferredStyle: .alert)
+                let okAction = UIAlertAction(title: "OK", style: .default, handler: nil)
+                alertController.addAction(okAction)
+                doAlert(alertController)
+            }
+            
+            alertController.addAction(cancelAction)
+            alertController.addAction(okAction)
+            doAlert(alertController)
+        }
+    }
+    
+    func makeUIViewController(context: UIViewControllerRepresentableContext<MainDataImportProcess>) -> UIDocumentPickerViewController {
+        let picker = UIDocumentPickerViewController(forOpeningContentTypes: [UTType.zip])
+        picker.delegate = context.coordinator
+        return picker
+    }
+    
+    func updateUIViewController(_ uiViewController: UIDocumentPickerViewController, context: UIViewControllerRepresentableContext<MainDataImportProcess>) {
+    }
+    
+    func makeCoordinator() -> MainDataImportProcess.Coordinator {
+        return Coordinator(self)
+    }
+}
+
+/// A view for 'help' with exporting your passwords
+struct MainDataImportView: View {
+    
+    /// An observable that contains the variable content of the view
+    @ObservedObject var mainDataImport: MainDataImportViewObservable
+    @State private var isPresented = false
+    
+    /// The body of the view
+    var body: some View {
+        NavigationView {
+            VStack(alignment: .leading, spacing: 10, content: {
+                Spacer()
+                Group {
+                    Text("Please read the following notice carefully!").bold()
+                    Divider()
+                    Text("The ZIP archive you select is assumed to be a backup previously exported from Raivo. You will be asked to provide the password necessary to decrypt it, which may or may not differ from your current master password.")
+                    Divider()
+                    Text("Any OTPs currently stored in Raivo will be erased. If in doubt, export your current OTPs first.")
+                    Divider()
+                    Text("Your master password will not be changed.")
+                }
+                Spacer()
+                FilledButtonText("Import") {
+                    self.isPresented = true
+                }.sheet(isPresented: $isPresented) {
+                    MainDataImportProcess()
+                }
+            })
+                .padding()
+                .navigationBarHidden(true)
+                .sheet(isPresented: $mainDataImport.present) {
+                    ActivityViewController(activityItems: [mainDataImport.archive!])
+                }
+        }
+        .navigationViewStyle(StackNavigationViewStyle())
+    }
+}
+
+/// A preview for the data import view
+struct MainDataImportView_Previews: PreviewProvider {
+    static var previews: some View {
+        MainDataImportView(mainDataImport: MainDataImportViewObservable())
+    }
+}


### PR DESCRIPTION
# PR Details

Users can now reimport OTPs previously exported from Raivo. Closes #22

![Screen_Recording_2023-03-31_at_11 22 52_PM](https://user-images.githubusercontent.com/45853441/229264852-c31e6bac-864a-428b-9b07-8d52753cae44.gif)

## Description

For every file related to exporting OTPs, I have created an equivalent for importing OTPs, e.g. I added `MainDataImportView`/`DataImportFeature`/etc to complement the existing `MainDataExportView`/`DataExportFeature`/etc.

The import process spans two steps: the user selects the ZIP file to import, and then they are prompted to enter the password required for decryption.

## Type of change

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:

- [x] My code follows the code style of this project.
- [x] My change generates no new warnings
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.